### PR TITLE
Ci/addtional settings

### DIFF
--- a/Costory/Costory/settings.py
+++ b/Costory/Costory/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'posts',
 ]
 
 MIDDLEWARE = [
@@ -104,7 +105,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Asia/Seoul'
 
 USE_I18N = True
 

--- a/Costory/Costory/urls.py
+++ b/Costory/Costory/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include('posts.urls')),
 ]

--- a/Costory/posts/urls.py
+++ b/Costory/posts/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    # path('', views.index),
+    # path('posts/', views.post_list),
+    # path('posts/new/', views.post_create),
+    # path('posts/<int:post_id>/', views.post_detail),
+    # path('posts/<int:post_id>/edit/', views.post_update),
+    # path('posts/<int:post_id>/delete/', views.post_delete),
+]


### PR DESCRIPTION
# 1. Add 'posts' app to INSTALLED_APPS and set timezone to Asia/Seoul commit 15afa7e5789b089f7f90bbd19a057f67034bb08b

This pull request includes the following changes to the Django project's settings.py file:

Added 'posts' app to INSTALLED_APPS
This enables Django to recognize and manage the new posts application.

Changed TIME_ZONE from 'UTC' to 'Asia/Seoul'
This ensures that all datetime operations are localized to Korean Standard Time (KST), which is appropriate for our region.

These updates are essential for initializing local app development and correct timezone handling.

# 2. ci/URL settings commit 135f0a6ca984602fcb833dfe49eb31300210fcf6

"게시글 앱 만들 건데, 나중에 사용할 URL 라우팅 미리 세팅해줘.
/posts/로 리스트, /posts/new/로 글 작성,
그리고 /posts/<id>/로 상세보기,
거기서 /edit/, /delete/ 같은 것도 붙여서 수정/삭제할 수 있게 하고 싶어.
뷰 함수는 아직 안 만들어서 일단 주석처리해놔도 되고!"

> [!TIP]
> <strong> 라우팅관련참고자료 </strong> </br>
> [관련 내 repository 참고](https://github.com/samon3869/Costaurant/pull/1)